### PR TITLE
Fix logic in token/JSON response error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ server.route([{
     var userFrom  = request.payload.userFrom;
     var userTo = request.payload.userTo;
 
-    if (!userFrom.token || !userFrom.emojiJson) {
+    if (!userFrom.token && !userFrom.emojiJson) {
       return reply(
         Boom.badRequest('You must enter either a token or a JSON response.'));
     } 


### PR DESCRIPTION
Currently, you must enter *both* a raw JSON response and a source team testing token.